### PR TITLE
Add stbmv kernel (only supports diagonal matrices for now)

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2020 Idein Inc. (info@idein.jp)
+Copyright (c) 2020-2021 Idein Inc. (info@idein.jp)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/include/cblas-qmkl6.h
+++ b/include/cblas-qmkl6.h
@@ -20,6 +20,16 @@ typedef enum {
   CblasConjTrans = 113,
 } CBLAS_TRANSPOSE;
 
+typedef enum {
+  CblasUpper = 121,
+  CblasLower = 122,
+} CBLAS_UPLO;
+
+typedef enum {
+  CblasNonUnit = 131,
+  CblasUnit = 132,
+} CBLAS_DIAG;
+
 /* qmkl6.cpp */
 
 void qmkl6_init(void);
@@ -51,6 +61,10 @@ void cblas_sscal(int n, float a, float *x, int incx);
 void cblas_sgemv(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE trans, int m, int n,
                  float alpha, const float *a, int lda, const float *x, int incx,
                  float beta, float *y, int incy);
+
+void cblas_stbmv(CBLAS_LAYOUT layout, CBLAS_UPLO uplo, CBLAS_TRANSPOSE trans,
+                 CBLAS_DIAG diag, int n, int k, const float *a, int lda,
+                 float *x, int incx);
 
 /* blas3.cpp */
 

--- a/include/qmkl6-internal.hpp
+++ b/include/qmkl6-internal.hpp
@@ -25,16 +25,16 @@ class qmkl6_context {
 
   uint32_t unif_handle, qpu_sasum_handle, qpu_saxpy_handle, qpu_scopy_handle,
       qpu_sdot_handle, qpu_snrm2_handle, qpu_sscal_handle, qpu_sgemv_n_handle,
-      qpu_sgemv_t_handle, qpu_sgemm_rnn_handle, qpu_sgemm_rnt_handle,
-      qpu_sgemm_rtn_handle, qpu_sgemm_rtt_handle;
+      qpu_sgemv_t_handle, qpu_stbmv_handle, qpu_sgemm_rnn_handle,
+      qpu_sgemm_rnt_handle, qpu_sgemm_rtn_handle, qpu_sgemm_rtt_handle;
   uint32_t unif_bus, qpu_sasum_bus, qpu_saxpy_bus, qpu_scopy_bus, qpu_sdot_bus,
       qpu_snrm2_bus, qpu_sscal_bus, qpu_sgemv_n_bus, qpu_sgemv_t_bus,
-      qpu_sgemm_rnn_bus, qpu_sgemm_rnt_bus, qpu_sgemm_rtn_bus,
+      qpu_stbmv_bus, qpu_sgemm_rnn_bus, qpu_sgemm_rnt_bus, qpu_sgemm_rtn_bus,
       qpu_sgemm_rtt_bus;
   uint32_t *unif;
   uint64_t *qpu_saxpy, *qpu_sasum, *qpu_scopy, *qpu_sdot, *qpu_snrm2,
-      *qpu_sscal, *qpu_sgemv_n, *qpu_sgemv_t, *qpu_sgemm_rnn, *qpu_sgemm_rnt,
-      *qpu_sgemm_rtn, *qpu_sgemm_rtt;
+      *qpu_sscal, *qpu_sgemv_n, *qpu_sgemv_t, *qpu_stbmv, *qpu_sgemm_rnn,
+      *qpu_sgemm_rnt, *qpu_sgemm_rtn, *qpu_sgemm_rtt;
 
   uint64_t timeout_ns = UINT64_C(10'000'000'000);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,10 +32,12 @@ set_property(SOURCE blas1.cpp APPEND PROPERTY
 
 add_qhex6_from_py(sgemv_n 8 0)
 add_qhex6_from_py(sgemv_t 8 0)
+add_qhex6_from_py(stbmv 8 1 0)
 
 set_property(SOURCE blas2.cpp APPEND PROPERTY
         OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/sgemv_n.qhex6
-                       ${CMAKE_CURRENT_BINARY_DIR}/sgemv_t.qhex6)
+                       ${CMAKE_CURRENT_BINARY_DIR}/sgemv_t.qhex6
+                       ${CMAKE_CURRENT_BINARY_DIR}/stbmv.qhex6)
 
 add_qhex6_from_py(sgemm_rnn 8 0)
 add_qhex6_from_py(sgemm_rnt 8 0)

--- a/src/blas2.cpp
+++ b/src/blas2.cpp
@@ -12,6 +12,10 @@ static const uint64_t qpu_sgemv_t_orig[] = {
 #include "sgemv_t.qhex6"
 };
 
+static const uint64_t qpu_stbmv_orig[] = {
+#include "stbmv.qhex6"
+};
+
 void cblas_sgemv(const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE trans,
                  const int m, const int n, const float alpha, const float *a,
                  const int lda, const float *x, const int incx,
@@ -129,6 +133,58 @@ void cblas_sgemv(const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE trans,
   for (int i = 0; i < ylen_qpu; ++i) y[incy * i] += y_host[i];
 }
 
+void cblas_stbmv([[maybe_unused]] const CBLAS_LAYOUT layout,
+                 [[maybe_unused]] const CBLAS_UPLO uplo,
+                 [[maybe_unused]] const CBLAS_TRANSPOSE trans,
+                 [[maybe_unused]] const CBLAS_DIAG diag, int n, const int k,
+                 const float *const a, const int lda, float *const x,
+                 const int incx) {
+  if (n <= 0) {
+    fprintf(stderr, "error: n (%d) must be greater than zero\n", n);
+    XERBLA(1);
+  }
+  if (k != 0) {
+    fprintf(stderr, "error: Diagonal matrices are only supported for now\n");
+    XERBLA(1);
+  }
+  if (lda <= 0) {
+    fprintf(stderr, "error: lda (%d) must be greater than zero\n", lda);
+    XERBLA(1);
+  }
+  if (incx <= 0) {
+    fprintf(stderr, "error: incx (%d) must be greater than zero\n", incx);
+    XERBLA(1);
+  }
+
+  const unsigned num_queues = 4, num_threads = 16, num_qpus = 8,
+                 unroll = 1 << 1,
+                 align = num_queues * num_threads * num_qpus * unroll;
+  const int n_rem = n % align;
+  n -= n_rem;
+
+  uint32_t a_handle, x_handle, a_bus, x_bus;
+
+  if (n > 0) {
+    qmkl6.locate_virt((void *)a, a_handle, a_bus);
+    qmkl6.locate_virt((void *)x, x_handle, x_bus);
+
+    qmkl6.unif[0] = n;
+    qmkl6.unif[1] = a_bus;
+    qmkl6.unif[2] = lda;
+    qmkl6.unif[3] = x_bus;
+    qmkl6.unif[4] = incx;
+
+    qmkl6.execute_qpu_code(qmkl6.qpu_stbmv_bus, qmkl6.unif_bus, num_qpus, 1,
+                           a_handle);
+  }
+
+  for (int i = 0, j = lda * n, k = incx * n; i < n_rem;
+       ++i, j += lda, k += incx)
+    x[k] *= a[j];
+
+  if (n > 0) qmkl6.wait_for_handles(qmkl6.timeout_ns, 1, a_handle);
+}
+
 void qmkl6_context::init_blas2(void) {
   qpu_sgemv_n = (uint64_t *)alloc_memory(sizeof(qpu_sgemv_n_orig),
                                          qpu_sgemv_n_handle, qpu_sgemv_n_bus);
@@ -137,9 +193,14 @@ void qmkl6_context::init_blas2(void) {
   qpu_sgemv_t = (uint64_t *)alloc_memory(sizeof(qpu_sgemv_t_orig),
                                          qpu_sgemv_t_handle, qpu_sgemv_t_bus);
   memcpy(qpu_sgemv_t, qpu_sgemv_t_orig, sizeof(qpu_sgemv_t_orig));
+
+  qpu_stbmv = (uint64_t *)alloc_memory(sizeof(qpu_stbmv_orig), qpu_stbmv_handle,
+                                       qpu_stbmv_bus);
+  memcpy(qpu_stbmv, qpu_stbmv_orig, sizeof(qpu_stbmv_orig));
 }
 
 void qmkl6_context::finalize_blas2(void) {
+  free_memory(sizeof(qpu_stbmv_orig), qpu_stbmv_handle, qpu_stbmv);
   free_memory(sizeof(qpu_sgemv_t_orig), qpu_sgemv_t_handle, qpu_sgemv_t);
   free_memory(sizeof(qpu_sgemv_n_orig), qpu_sgemv_n_handle, qpu_sgemv_n);
 }

--- a/src/stbmv.py
+++ b/src/stbmv.py
@@ -1,0 +1,118 @@
+
+import sys
+
+from videocore6.assembler import assemble, qpu
+
+
+@qpu
+def qpu_stbmv(asm, *, num_qpus, unroll_shift, code_offset,
+              align_cond=lambda pos: True):
+
+    g = globals()
+    for i, v in enumerate(['length', 'x', 'x_inc', 'y_src', 'y_dst', 'y_inc',
+                           'qpu_num']):
+        g[f'reg_{v}'] = rf[i]
+
+    nop(sig=ldunifrf(reg_length))
+    nop(sig=ldunifrf(reg_x))
+    nop(sig=ldunifrf(reg_x_inc))
+    nop(sig=ldunifrf(reg_y_src))
+    nop(sig=ldunifrf(reg_y_inc))
+
+    if num_qpus == 1:
+        num_qpus_shift = 0
+        mov(reg_qpu_num, 0)
+    elif num_qpus == 8:
+        num_qpus_shift = 3
+        tidx(r0)
+        shr(r0, r0, 2)
+        band(reg_qpu_num, r0, 0b1111)
+    else:
+        raise Exception('num_qpus must be 1 or 8')
+
+    # addr += 4 * (thread_num + 16 * qpu_num) * inc
+    shl(r0, reg_qpu_num, 4)
+    eidx(r1)
+    add(r0, r0, r1)
+    shl(r0, r0, 2)
+    umul24(r1, r0, reg_x_inc)
+    add(reg_x, reg_x, r1).umul24(r1, r0, reg_y_inc)
+    add(reg_y_src, reg_y_src, r1).add(reg_y_dst, reg_y_src, r1)
+
+    # inc *= 4 * 16 * num_qpus
+    mov(r0, 1)
+    shl(r0, r0, 6 + num_qpus_shift)
+    umul24(reg_x_inc, reg_x_inc, r0)
+    umul24(reg_y_inc, reg_y_inc, r0)
+
+    # length /= 16 * 4 * num_qpus * unroll
+    shr(reg_length, reg_length, 4 + 2 + num_qpus_shift + unroll_shift)
+
+    nop(sig=thrsw)
+    nop()
+    nop()
+
+    while not align_cond(code_offset + len(asm)):
+        nop()
+
+    with loop as l:
+
+        unroll = 1 << unroll_shift
+
+        for i in range(4):
+            mov(tmua, reg_x).add(reg_x, reg_x, reg_x_inc)
+            mov(tmua, reg_y_src).add(reg_y_src, reg_y_src, reg_y_inc)
+
+        for j in range(unroll - 1):
+            for i in range(4):
+                nop(sig=ldtmu(r0))
+                nop(sig=ldtmu(r1))
+                fmul(tmud, r0, r1)
+                mov(tmua, reg_y_dst).add(reg_y_dst, reg_y_dst, reg_y_inc)
+                mov(tmua, reg_x).add(reg_x, reg_x, reg_x_inc)
+                mov(tmua, reg_y_src).add(reg_y_src, reg_y_src, reg_y_inc)
+
+        for i in range(2):
+            nop(sig=ldtmu(r0))
+            nop(sig=ldtmu(r1))
+            fmul(tmud, r0, r1)
+            mov(tmua, reg_y_dst).add(reg_y_dst, reg_y_dst, reg_y_inc)
+
+        nop(sig=ldtmu(r0))
+        nop(sig=ldtmu(r1))
+        sub(reg_length, reg_length, 1, cond='pushz').fmul(tmud, r0, r1)
+        mov(tmua, reg_y_dst).add(reg_y_dst, reg_y_dst, reg_y_inc)
+
+        nop(sig=ldtmu(r0))
+
+        l.b(cond='na0')
+        nop(sig=ldtmu(r1))                                         # delay slot
+        fmul(tmud, r0, r1)                                         # delay slot
+        mov(tmua, reg_y_dst).add(reg_y_dst, reg_y_dst, reg_y_inc)  # delay slot
+
+    barrierid(syncb, sig=thrsw)
+    nop()
+    nop()
+
+    nop(sig=thrsw)
+    nop(sig=thrsw)
+    nop()
+    nop()
+    nop(sig=thrsw)
+    nop()
+    nop()
+    nop()
+
+
+def main():
+
+    num_qpus, unroll_shift, code_offset = map(int, sys.argv[1:])
+
+    for insn in assemble(qpu_stbmv, num_qpus=num_qpus,
+                         unroll_shift=unroll_shift, code_offset=code_offset):
+        print(f'UINT64_C({insn:#018x}),')
+
+
+if __name__ == '__main__':
+
+    main()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # libatlas-base-dev, libblas-dev, libopenblas-dev
 set(blas_list qmkl6 atlas netlib openblas)
-set(test_list mem sasum saxpy scopy sdot snrm2 sscal sgemv sgemm)
+set(test_list mem sasum saxpy scopy sdot snrm2 sscal sgemv stbmv sgemm)
 
 include_directories(${CMAKE_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR})
 add_compile_options(-pipe -W -Wall -Wextra -O2 -g -std=c++17)

--- a/test/stbmv.cpp
+++ b/test/stbmv.cpp
@@ -1,0 +1,110 @@
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <iostream>
+#include <random>
+
+#include "cblasdefs.h"
+
+static void naive_stbmv([[maybe_unused]] const CBLAS_LAYOUT layout,
+                        [[maybe_unused]] const CBLAS_UPLO uplo,
+                        [[maybe_unused]] const CBLAS_TRANSPOSE trans,
+                        [[maybe_unused]] const CBLAS_DIAG diag, const int n,
+                        const int k, const float *const a, const int lda,
+                        float *const x, const int incx) {
+  if (k != 0) {
+    std::cerr << "error: We only support diagonal matrices for now"
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+
+#pragma omp parallel for default(none) firstprivate(n, a, lda, x, incx) \
+    schedule(guided)
+  for (int i = 0; i < n; ++i) x[incx * i] *= a[lda * i];
+}
+
+template <class Generator>
+static int test_stbmv_diag_single(const int n, const int lda, const int incx,
+                                  Generator &gen) {
+  float *a, *x0, *x1;
+  std::uniform_real_distribution<float> dist;
+
+  printf("n = %5d, lda = %5d, incx = %d: ", n, lda, incx);
+
+  a = (float *)mkl_malloc(n * lda * sizeof(float), 64);
+  std::generate(a, a + n * lda, std::bind(dist, gen));
+
+  x0 = (float *)malloc((1 + (n - 1) * incx) * sizeof(float));
+  x1 = (float *)mkl_malloc((1 + (n - 1) * incx) * sizeof(float), 64);
+  std::generate(x0, x0 + (1 + (n - 1) * incx), std::bind(dist, gen));
+  memcpy(x1, x0, (1 + (n - 1) * incx) * sizeof(float));
+
+  const double start0 = dsecond();
+  naive_stbmv(CblasRowMajor, CblasUpper, CblasNoTrans, CblasNonUnit, n, 0, a,
+              lda, x0, incx);
+  const double end0 = dsecond();
+
+  const double start1 = dsecond();
+  cblas_stbmv(CblasRowMajor, CblasUpper, CblasNoTrans, CblasNonUnit, n, 0, a,
+              lda, x1, incx);
+  const double end1 = dsecond();
+
+  float err_abs_min = HUGE_VALF, err_abs_max = -HUGE_VALF;
+  float err_rel_min = HUGE_VALF, err_rel_max = -HUGE_VALF;
+  for (int i = 0; i < n; ++i) {
+    const float err_abs = std::abs(x0[incx * i] - x1[incx * i]);
+    const float err_rel = std::abs(err_abs / x0[incx * i]);
+    err_abs_min = std::min(err_abs_min, err_abs);
+    err_abs_max = std::max(err_abs_max, err_abs);
+    err_rel_min = std::min(err_rel_min, err_rel);
+    err_rel_max = std::max(err_rel_max, err_rel);
+  }
+
+  printf(
+      "err_abs = [%f, %f], "
+      "err_rel = [%f, %f], "
+      "%f sec -> %f sec, "
+      "%f Mflop/s -> %f Mflop/s\n",
+      err_abs_min, err_abs_max, err_rel_min, err_rel_max, end0 - start0,
+      end1 - start1, n / (end0 - start0) * 1e-6, n / (end1 - start1) * 1e-6);
+
+  if (err_rel_max > 1e-3f) {
+    std::cerr << "error: Absolute error is too large\n" << std::endl;
+    return 1;
+  }
+
+  mkl_free(a);
+  free(x0);
+  mkl_free(x1);
+  return 0;
+}
+
+template <class Generator>
+static int test_stbmv_diag_random(Generator &gen) {
+  std::uniform_int_distribution<int> dist_int;
+
+  dist_int.param(decltype(dist_int)::param_type(1, 1 << 16));
+  const int n = dist_int(gen);
+
+  dist_int.param(decltype(dist_int)::param_type(1, 8));
+  const int incx = dist_int(gen), lda = dist_int(gen);
+
+  return test_stbmv_diag_single(n, lda, incx, gen);
+}
+
+int main(void) {
+  setbuf(stdout, NULL);
+
+  std::default_random_engine gen;
+  int ret;
+
+  for (int i = 0; i < 10; ++i) {
+    ret = test_stbmv_diag_random(gen);
+    if (ret) return ret;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
The original `stbmv` kernel performs single-precision triangular band matrix-vector multiplication.
If the width of the band is one, then the matrix is a diagonal matrix and the values in the input vector is multiplied by the corresponding value of the diagonal in the matrix.
In addition, only the diagonal portions of the matrix are stored in the memory.
That is to say, `stbmv` with a diagonal matrix is equivalent to the element-wise product of two vectors.
This pull request adds the kernel that only supports diagonal matrices for this purpose.

Though Intel MKL offers the operation as `vsMul`, most other BLAS libraries do not.
So it should be an acceptable way (for testing in particular) to serve the operation through `stbmv`, which is supported by most libraries.

The implementation of the QPU kernel is based on `saxpy`.