### PR TITLE
CMake: Add test-only mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on: [push]
+on: push
 
 jobs:
 
@@ -21,3 +21,29 @@ jobs:
             clang-format "$f" | diff -u "$f" - || ret=1
           done <<<"$(git ls-files \*.cpp \*.h \*.hpp)"
           exit "$ret"
+
+  run-tests:
+    runs-on: ubuntu-latest
+    container: debian:buster
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install required packages
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends build-essential pkg-config cmake libblas-dev libopenblas-dev libatlas-base-dev
+          apt-get clean
+          rm -rf /var/lib/apt/lists/*
+      - name: Build tests
+        run: |
+          mkdir build/
+          cd build/
+          cmake .. -DBUILD_TESTING=TRUE -DNO_QMKL6=TRUE
+          make
+      - name: Run tests
+        run: |
+          tail -n +1 /proc/cpuinfo /proc/meminfo
+          echo
+          cd build/
+          ctest -V

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,32 +4,42 @@ cmake_minimum_required(VERSION 3.12)
 project(qmkl6 VERSION 0.0.0 LANGUAGES CXX
         DESCRIPTION "Math Kernel Library for VideoCore VI QPU")
 
-set(CPACK_GENERATOR "DEB")
-set(CPACK_PACKAGE_CONTACT "Yukimasa Sugizaki <ysugi@idein.jp>")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY ${PROJECT_DESCRIPTION})
-set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
-set(CPACK_DEBIAN_PACKAGE_DEPENDS libdrm_v3d)
-
-if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set(CMAKE_INSTALL_PREFIX /usr CACHE PATH "Install prefix" FORCE)
-endif ()
-set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
-message(STATUS "Install prefix is set to ${CMAKE_INSTALL_PREFIX}")
-
-include(GNUInstallDirs)
-include(CPack)
 include(CTest)
 
-find_package(OpenMP)
 find_package(PkgConfig)
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
-pkg_check_modules(DRM_V3D REQUIRED libdrm_v3d)
+if (NO_QMKL6)
 
-add_subdirectory(include)
-add_subdirectory(src)
+    message(STATUS "Not building QMKL6 because NO_QMKL6 is set")
+
+else (NO_QMKL6)
+
+    set(CPACK_GENERATOR "DEB")
+    set(CPACK_PACKAGE_CONTACT "Yukimasa Sugizaki <ysugi@idein.jp>")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY ${PROJECT_DESCRIPTION})
+    set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS libdrm_v3d)
+
+    if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+        set(CMAKE_INSTALL_PREFIX /usr CACHE PATH "Install prefix" FORCE)
+    endif ()
+    set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+    message(STATUS "Install prefix is set to ${CMAKE_INSTALL_PREFIX}")
+
+    include(GNUInstallDirs)
+    include(CPack)
+
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+    pkg_check_modules(DRM_V3D REQUIRED libdrm_v3d)
+
+    add_subdirectory(include)
+    add_subdirectory(src)
+
+    configure_file(blas-qmkl6.pc.in blas-qmkl6.pc @ONLY)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/blas-qmkl6.pc
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+endif (NO_QMKL6)
+
 add_subdirectory(test)
-
-configure_file(blas-qmkl6.pc.in blas-qmkl6.pc @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/blas-qmkl6.pc
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,40 +1,43 @@
-# libatlas-base-dev, libblas-dev, libopenblas-dev
-set(blas_list qmkl6 atlas netlib openblas)
-set(test_list mem sasum saxpy scopy sdot snrm2 sscal sgemv stbmv sgemm)
+if (NOT BUILD_TESTING)
+    return()
+endif ()
+
+find_package(OpenMP)
 
 include_directories(${CMAKE_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR})
 add_compile_options(-pipe -W -Wall -Wextra -O2 -g -std=c++17)
 
-set(qmkl6_LINK_LIBRARIES ${DRM_V3D_LINK_LIBRARIES} qmkl6)
+# libblas-dev, libopenblas-dev, libatlas-base-dev
+pkg_check_modules(netlib blas-netlib)
+pkg_check_modules(openblas blas-openblas)
+pkg_check_modules(atlas blas-atlas)
 
-if (BUILD_TESTING)
+if (NOT NO_QMKL6)
+    set(qmkl6_FOUND TRUE)
+    set(qmkl6_LINK_LIBRARIES ${DRM_V3D_LINK_LIBRARIES} qmkl6)
+endif (NOT NO_QMKL6)
 
-    foreach (blas IN LISTS blas_list)
+foreach (blas IN ITEMS qmkl6 netlib openblas atlas)
 
-        if (NOT blas STREQUAL qmkl6)
-            pkg_check_modules(${blas} blas-${blas})
+    if (NOT ${blas}_FOUND)
+        continue()
+    endif ()
 
-            if (NOT ${blas}_FOUND)
-                continue()
-            endif ()
+    foreach (test IN ITEMS mem sasum saxpy scopy sdot snrm2 sscal sgemv stbmv
+                           sgemm)
+
+        if (NOT blas STREQUAL qmkl6 AND test STREQUAL mem)
+            continue()
         endif ()
 
-        foreach (test IN LISTS test_list)
+        add_executable(${test}-${blas} ${test}.cpp)
+        target_compile_definitions(${test}-${blas} PUBLIC CBLAS_${blas})
+        target_link_libraries(${test}-${blas} ${${blas}_LINK_LIBRARIES})
+        if (OpenMP_CXX_FOUND)
+            target_link_libraries(${test}-${blas} OpenMP::OpenMP_CXX)
+        endif ()
+        add_test(${test}-${blas} ${test}-${blas})
 
-            if (NOT blas STREQUAL qmkl6 AND test STREQUAL mem)
-                continue()
-            endif ()
+    endforeach()
 
-            add_executable(${test}-${blas} ${test}.cpp)
-            target_compile_definitions(${test}-${blas} PUBLIC CBLAS_${blas})
-            target_link_libraries(${test}-${blas} ${${blas}_LINK_LIBRARIES})
-            if (OpenMP_CXX_FOUND)
-                target_link_libraries(${test}-${blas} OpenMP::OpenMP_CXX)
-            endif ()
-            add_test(${test}-${blas} ${test}-${blas})
-
-        endforeach()
-
-    endforeach ()
-
-endif ()
+endforeach ()

--- a/test/sasum.cpp
+++ b/test/sasum.cpp
@@ -13,7 +13,7 @@ static int test_sasum_single(const size_t n) {
 
   float asum_exp = 0.f;
   for (size_t i = 0; i < n; ++i) {
-    x[i] = (i & 1) ? -i : i;
+    x[i] = (i & 1) ? -(float)i : i;
     asum_exp += i;
   }
 

--- a/test/saxpy.cpp
+++ b/test/saxpy.cpp
@@ -46,8 +46,8 @@ static int test_saxpy_single(const size_t n) {
   printf("Minimum/maximum absolute errors: %e, %e\n", err_abs_min, err_abs_max);
   printf("Minimum/maximum relative errors: %e, %e\n", err_rel_min, err_rel_max);
 
-  if (err_abs_max != 0.f || err_rel_max != 0.f) {
-    std::cerr << "error: The results contain too large errors" << std::endl;
+  if (err_rel_max > 1e-3f) {
+    std::cerr << "error: The maximum relative error is too large" << std::endl;
     return 1;
   }
 
@@ -102,7 +102,7 @@ static int test_saxpy_random(void) {
     printf("Minimum/maximum relative errors: %e, %e\n", err_rel_min,
            err_rel_max);
 
-    if (err_rel_max != 0.f) {
+    if (err_rel_max > 1e-3f) {
       std::cerr << "error: The maximum relative error is too large"
                 << std::endl;
       return 1;

--- a/test/saxpy.cpp
+++ b/test/saxpy.cpp
@@ -22,7 +22,7 @@ static int test_saxpy_single(const size_t n) {
 
   for (size_t i = 0; i < n; ++i) {
     x[i] = i;
-    y[i] = -i;
+    y[i] = -(float)i;
     y_orig[i] = coef * x[i] + y[i];
   }
 

--- a/test/sdot.cpp
+++ b/test/sdot.cpp
@@ -24,16 +24,18 @@ static int test_sdot_single(const size_t n) {
   const float res_act = cblas_sdot(n, x, 1, y, 1);
   const double end = dsecond();
 
+  const float err_abs = std::abs(res_exp - res_act);
+  const float err_rel = std::abs(err_abs / res_exp);
+
   printf("Result (actual): %e\n", res_act);
-  printf("Absolute error: %e\n", std::abs(res_exp - res_act));
-  printf("Relative error: %e\n", std::abs(1 - res_act / res_exp));
+  printf("Absolute error: %e\n", err_abs);
+  printf("Relative error: %e\n", err_rel);
 
   printf("%zu elements, %f sec, %f Mflop/s\n", n, end - start,
          n / (end - start) * 1e-6);
 
-  if (res_act != res_exp) {
-    std::cerr << "error: The actual result is different from expected"
-              << std::endl;
+  if (err_rel > 1e-3f) {
+    std::cerr << "error: Relative error is too large" << std::endl;
     return 1;
   }
 

--- a/test/sgemv.cpp
+++ b/test/sgemv.cpp
@@ -116,7 +116,7 @@ static int test_sgemv_single(const CBLAS_LAYOUT layout,
          (2. * xlen * ylen + ylen) / (end - start) * 1e-6);
 
   if (err_rel_max > 1e-3f) {
-    std::cerr << "error: Absolute error is too large\n" << std::endl;
+    std::cerr << "error: Absolute error is too large" << std::endl;
     return 1;
   }
 

--- a/test/sscal.cpp
+++ b/test/sscal.cpp
@@ -35,7 +35,7 @@ static int test_sscal_single(const size_t n) {
   printf("Minimum/maximum relative errors: %e, %e\n", err_rel_min, err_rel_max);
 
   if (err_rel_max > 1e-3f) {
-    std::cerr << "error: Relative error is too large\n" << std::endl;
+    std::cerr << "error: Relative error is too large" << std::endl;
     return 1;
   }
 

--- a/test/sscal.cpp
+++ b/test/sscal.cpp
@@ -34,8 +34,8 @@ static int test_sscal_single(const size_t n) {
   printf("Minimum/maximum absolute errors: %e, %e\n", err_abs_min, err_abs_max);
   printf("Minimum/maximum relative errors: %e, %e\n", err_rel_min, err_rel_max);
 
-  if (err_abs_max != 0.f || err_rel_max != 0.f) {
-    std::cerr << "error: The results contain too large errors" << std::endl;
+  if (err_rel_max > 1e-3f) {
+    std::cerr << "error: Relative error is too large\n" << std::endl;
     return 1;
   }
 

--- a/test/stbmv.cpp
+++ b/test/stbmv.cpp
@@ -72,7 +72,7 @@ static int test_stbmv_diag_single(const int n, const int lda, const int incx,
       end1 - start1, n / (end0 - start0) * 1e-6, n / (end1 - start1) * 1e-6);
 
   if (err_rel_max > 1e-3f) {
-    std::cerr << "error: Absolute error is too large\n" << std::endl;
+    std::cerr << "error: Absolute error is too large" << std::endl;
     return 1;
   }
 


### PR DESCRIPTION
Add the `NO_QMKL6` option to specify whether we only need to build tests or not.
With the help of this option, we can now test if the testing codes run correctly on machines other than Raspberry Pi.