### PR TITLE
Add BLAS-like somatcopy kernel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,13 +14,11 @@ jobs:
           sudo apt-get install -y --no-install-recommends git clang-format
           sudo apt-get clean
           sudo rm -rf /var/lib/apt/lists/*
+          clang-format -version
       - name: Run clang-format
         run: |
-          ret=0
-          while read f; do
-            clang-format "$f" | diff -u "$f" - || ret=1
-          done <<<"$(git ls-files \*.cpp \*.h \*.hpp)"
-          exit "$ret"
+          git ls-files '*.cpp' '*.h' '*.hpp' | xargs clang-format -verbose -i
+          git diff --exit-code
 
   code-format-py:
     runs-on: ubuntu-latest
@@ -28,11 +26,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: '3.x'
       - name: Install autopep8
-        run: pip3 install autopep8
+        run: |
+          pip3 install autopep8
+          autopep8 --version
       - name: Run autopep8
-        run: git ls-files \*.py | xargs autopep8 --diff --exit-code
+        run: git ls-files '*.py' | xargs autopep8 --diff --exit-code
 
   run-tests:
     runs-on: ubuntu-latest
@@ -74,7 +74,7 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends ca-certificates curl gnupg pkg-config make cmake binutils libstdc++-9-dev
           curl --silent 'https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB' | apt-key add -
-          echo 'deb https://apt.repos.intel.com/oneapi all main' | tee -a /etc/apt/sources.list.d/intel.list
+          echo 'deb https://apt.repos.intel.com/oneapi all main' >>/etc/apt/sources.list.d/intel.list
           apt-get update
           apt-get install -y --no-install-recommends intel-oneapi-compiler-dpcpp-cpp intel-oneapi-mkl-devel
           apt-get clean

--- a/include/cblas-qmkl6.h
+++ b/include/cblas-qmkl6.h
@@ -30,11 +30,6 @@ typedef enum {
   CblasUnit = 132,
 } CBLAS_DIAG;
 
-/* qmkl6.cpp */
-
-void qmkl6_init(void);
-void qmkl6_finalize(void);
-
 /* support.cpp */
 
 typedef void (*MKLExitHandler)(int why);

--- a/include/cblas-qmkl6.h
+++ b/include/cblas-qmkl6.h
@@ -68,6 +68,12 @@ void cblas_sgemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa,
                  const float *a, int lda, const float *b, int ldb, float beta,
                  float *c, int ldc);
 
+/* blaslike.cpp */
+
+void cblas_somatcopy(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE trans, int rows,
+                     int cols, float alpha, const float *a, int lda, float *b,
+                     int ldb);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/include/qmkl6-internal.hpp
+++ b/include/qmkl6-internal.hpp
@@ -26,15 +26,19 @@ class qmkl6_context {
   uint32_t unif_handle, qpu_sasum_handle, qpu_saxpy_handle, qpu_scopy_handle,
       qpu_sdot_handle, qpu_snrm2_handle, qpu_sscal_handle, qpu_sgemv_n_handle,
       qpu_sgemv_t_handle, qpu_stbmv_handle, qpu_sgemm_rnn_handle,
-      qpu_sgemm_rnt_handle, qpu_sgemm_rtn_handle, qpu_sgemm_rtt_handle;
+      qpu_sgemm_rnt_handle, qpu_sgemm_rtn_handle, qpu_sgemm_rtt_handle,
+      qpu_somatcopy_n_handle, qpu_somatcopy_t_4x4_handle,
+      qpu_somatcopy_t_512x32_handle;
   uint32_t unif_bus, qpu_sasum_bus, qpu_saxpy_bus, qpu_scopy_bus, qpu_sdot_bus,
       qpu_snrm2_bus, qpu_sscal_bus, qpu_sgemv_n_bus, qpu_sgemv_t_bus,
       qpu_stbmv_bus, qpu_sgemm_rnn_bus, qpu_sgemm_rnt_bus, qpu_sgemm_rtn_bus,
-      qpu_sgemm_rtt_bus;
+      qpu_sgemm_rtt_bus, qpu_somatcopy_n_bus, qpu_somatcopy_t_4x4_bus,
+      qpu_somatcopy_t_512x32_bus;
   uint32_t *unif;
   uint64_t *qpu_saxpy, *qpu_sasum, *qpu_scopy, *qpu_sdot, *qpu_snrm2,
       *qpu_sscal, *qpu_sgemv_n, *qpu_sgemv_t, *qpu_stbmv, *qpu_sgemm_rnn,
-      *qpu_sgemm_rnt, *qpu_sgemm_rtn, *qpu_sgemm_rtt;
+      *qpu_sgemm_rnt, *qpu_sgemm_rtn, *qpu_sgemm_rtt, *qpu_somatcopy_n,
+      *qpu_somatcopy_t_4x4, *qpu_somatcopy_t_512x32;
 
   uint64_t timeout_ns = UINT64_C(10'000'000'000);
 
@@ -90,6 +94,11 @@ class qmkl6_context {
 
   void init_blas3(void);
   void finalize_blas3(void);
+
+  /* blaslike.cpp */
+
+  void init_blaslike(void);
+  void finalize_blaslike(void);
 };
 
 extern qmkl6_context qmkl6;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,16 @@ set_property(SOURCE blas3.cpp APPEND PROPERTY
                        ${CMAKE_CURRENT_BINARY_DIR}/sgemm_rtn.qhex6
                        ${CMAKE_CURRENT_BINARY_DIR}/sgemm_rtt.qhex6)
 
-add_library(qmkl6 SHARED qmkl6.cpp support.cpp blas1.cpp blas2.cpp blas3.cpp)
+generate_qhex6_from_py(somatcopy_n somatcopy_n.py 8 8 0)
+generate_qhex6_from_py(somatcopy_t_4x4 somatcopy_t.py 8 1 1 4 4 0)
+generate_qhex6_from_py(somatcopy_t_512x32 somatcopy_t.py 8 8 8 4 4 0)
+
+set_property(SOURCE blaslike.cpp APPEND PROPERTY
+        OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/somatcopy_n.qhex6
+                       ${CMAKE_CURRENT_BINARY_DIR}/somatcopy_t_4x4.qhex6
+                       ${CMAKE_CURRENT_BINARY_DIR}/somatcopy_t_512x32.qhex6)
+
+add_library(qmkl6 SHARED qmkl6.cpp support.cpp blas1.cpp blas2.cpp blas3.cpp
+                         blaslike.cpp)
 
 install(TARGETS qmkl6 LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,26 +1,27 @@
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR}/include)
 add_compile_options(-pipe -W -Wall -Wextra -O2 -g -std=c++17)
 
-function (add_qhex6_from_py name)
+function (generate_qhex6_from_py name input)
 
     list(JOIN ARGN " " ARGN_string)
 
     add_custom_command(
-        DEPENDS ${name}.py
-        OUTPUT ${name}.qhex6
-        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${name}.py
-                ${ARGN} >${CMAKE_CURRENT_BINARY_DIR}/${name}.qhex6
-        COMMENT "Assembling ${name}.py with arguments: ${ARGN_string}"
+        DEPENDS "${input}"
+        OUTPUT "${name}.qhex6"
+        COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/${input}"
+                ${ARGN} > "${name}.qhex6"
+        VERBATIM
+        COMMENT "Generating ${name}.qhex6 from ${input} ${ARGN_string}"
     )
 
 endfunction ()
 
-add_qhex6_from_py(sasum 8 5 0)
-add_qhex6_from_py(saxpy 8 1 0)
-add_qhex6_from_py(scopy 8 0 0)
-add_qhex6_from_py(sdot 8 4 0)
-add_qhex6_from_py(snrm2 8 5 0)
-add_qhex6_from_py(sscal 8 0 0)
+generate_qhex6_from_py(sasum sasum.py 8 5 0)
+generate_qhex6_from_py(saxpy saxpy.py 8 1 0)
+generate_qhex6_from_py(scopy scopy.py 8 0 0)
+generate_qhex6_from_py(sdot sdot.py 8 4 0)
+generate_qhex6_from_py(snrm2 snrm2.py 8 5 0)
+generate_qhex6_from_py(sscal sscal.py 8 0 0)
 
 set_property(SOURCE blas1.cpp APPEND PROPERTY
         OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/sasum.qhex6
@@ -30,19 +31,19 @@ set_property(SOURCE blas1.cpp APPEND PROPERTY
                        ${CMAKE_CURRENT_BINARY_DIR}/snrm2.qhex6
                        ${CMAKE_CURRENT_BINARY_DIR}/sscal.qhex6)
 
-add_qhex6_from_py(sgemv_n 8 0)
-add_qhex6_from_py(sgemv_t 8 0)
-add_qhex6_from_py(stbmv 8 1 0)
+generate_qhex6_from_py(sgemv_n sgemv_n.py 8 0)
+generate_qhex6_from_py(sgemv_t sgemv_t.py 8 0)
+generate_qhex6_from_py(stbmv stbmv.py 8 1 0)
 
 set_property(SOURCE blas2.cpp APPEND PROPERTY
         OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/sgemv_n.qhex6
                        ${CMAKE_CURRENT_BINARY_DIR}/sgemv_t.qhex6
                        ${CMAKE_CURRENT_BINARY_DIR}/stbmv.qhex6)
 
-add_qhex6_from_py(sgemm_rnn 8 0)
-add_qhex6_from_py(sgemm_rnt 8 0)
-add_qhex6_from_py(sgemm_rtn 8 0)
-add_qhex6_from_py(sgemm_rtt 8 0)
+generate_qhex6_from_py(sgemm_rnn sgemm_rnn.py 8 0)
+generate_qhex6_from_py(sgemm_rnt sgemm_rnt.py 8 0)
+generate_qhex6_from_py(sgemm_rtn sgemm_rtn.py 8 0)
+generate_qhex6_from_py(sgemm_rtt sgemm_rtt.py 8 0)
 
 set_property(SOURCE blas3.cpp APPEND PROPERTY
         OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/sgemm_rnn.qhex6

--- a/src/blaslike.cpp
+++ b/src/blaslike.cpp
@@ -1,0 +1,133 @@
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+#include "cblas-qmkl6.h"
+#include "qmkl6-internal.hpp"
+
+/* somatcopy: B = a * op(A) */
+
+static const uint64_t qpu_somatcopy_n_orig[] = {
+#include "somatcopy_n.qhex6"
+};
+
+static const uint64_t qpu_somatcopy_t_4x4_orig[] = {
+#include "somatcopy_t_4x4.qhex6"
+};
+
+static const uint64_t qpu_somatcopy_t_512x32_orig[] = {
+#include "somatcopy_t_512x32.qhex6"
+};
+
+void cblas_somatcopy(const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE trans,
+                     const int rows, const int cols, const float alpha,
+                     const float* const a, const int lda, float* const b,
+                     const int ldb) {
+  constexpr int num_qpus = 8;
+
+  if (trans != CblasNoTrans && trans != CblasTrans) {
+    fprintf(stderr,
+            "error: trans must be NoTrans or Trans for single precision\n");
+    XERBLA(1);
+  }
+  if (rows <= 0) {
+    fprintf(stderr, "error: rows (%d) must be greater than zero\n", rows);
+    XERBLA(1);
+  }
+  if (cols <= 0) {
+    fprintf(stderr, "error: cols (%d) must be greater than zero\n", cols);
+    XERBLA(1);
+  }
+  if (layout == CblasRowMajor) {
+    if (lda < cols) {
+      fprintf(stderr,
+              "error: lda (%d) must not be smaller than cols (%d)"
+              " for row major\n",
+              lda, cols);
+      XERBLA(1);
+    }
+  } else {
+    if (lda < rows) {
+      fprintf(stderr,
+              "error: lda (%d) must not be smaller than rows (%d)"
+              " for column major\n",
+              lda, rows);
+      XERBLA(1);
+    }
+  }
+  if ((layout == CblasRowMajor) == (trans == CblasNoTrans)) {
+    if (ldb < cols) {
+      fprintf(stderr,
+              "error: ldb (%d) must not be smaller than cols (%d)"
+              " for row major, no trans type\n",
+              ldb, cols);
+      XERBLA(1);
+    }
+  } else {
+    if (ldb < rows) {
+      fprintf(stderr,
+              "error: ldb (%d) must not be smaller than rows (%d)"
+              " for row major, trans type\n",
+              ldb, rows);
+      XERBLA(1);
+    }
+  }
+
+  if (trans == CblasTrans && (rows % 4 != 0 || cols % 4 != 0)) {
+    fprintf(stderr,
+            "error: rows (%d) and cols (%d) must be a multiple of four"
+            " for trans for now\n",
+            rows, cols);
+    XERBLA(1);
+  }
+
+  uint32_t a_handle, b_handle;
+  uint32_t a_bus, b_bus;
+
+  qmkl6.locate_virt((void*)a, a_handle, a_bus);
+  qmkl6.locate_virt((void*)b, b_handle, b_bus);
+
+  qmkl6.unif[0] = (layout == CblasRowMajor) ? rows : cols;
+  qmkl6.unif[1] = (layout == CblasRowMajor) ? cols : rows;
+  qmkl6.unif[2] = qmkl6.bit_cast<uint32_t>(alpha);
+  qmkl6.unif[3] = a_bus;
+  qmkl6.unif[4] = 4 * lda;
+  qmkl6.unif[5] = b_bus;
+  qmkl6.unif[6] = 4 * ldb;
+
+  qmkl6.execute_qpu_code(
+      (trans == CblasNoTrans)
+          ? qmkl6.qpu_somatcopy_n_bus
+          : (qmkl6.unif[0] % 512 == 0 && qmkl6.unif[1] % 32 == 0)
+                ? qmkl6.qpu_somatcopy_t_512x32_bus
+                : qmkl6.qpu_somatcopy_t_4x4_bus,
+      qmkl6.unif_bus, num_qpus, 1, b_handle);
+
+  qmkl6.wait_for_handles(qmkl6.timeout_ns, 1, b_handle);
+}
+
+void qmkl6_context::init_blaslike(void) {
+  qpu_somatcopy_n =
+      (uint64_t*)alloc_memory(sizeof(qpu_somatcopy_n_orig),
+                              qpu_somatcopy_n_handle, qpu_somatcopy_n_bus);
+  memcpy(qpu_somatcopy_n, qpu_somatcopy_n_orig, sizeof(qpu_somatcopy_n_orig));
+  qpu_somatcopy_t_4x4 = (uint64_t*)alloc_memory(
+      sizeof(qpu_somatcopy_t_4x4_orig), qpu_somatcopy_t_4x4_handle,
+      qpu_somatcopy_t_4x4_bus);
+  memcpy(qpu_somatcopy_t_4x4, qpu_somatcopy_t_4x4_orig,
+         sizeof(qpu_somatcopy_t_4x4_orig));
+  qpu_somatcopy_t_512x32 = (uint64_t*)alloc_memory(
+      sizeof(qpu_somatcopy_t_512x32_orig), qpu_somatcopy_t_512x32_handle,
+      qpu_somatcopy_t_512x32_bus);
+  memcpy(qpu_somatcopy_t_512x32, qpu_somatcopy_t_512x32_orig,
+         sizeof(qpu_somatcopy_t_512x32_orig));
+}
+
+void qmkl6_context::finalize_blaslike(void) {
+  free_memory(sizeof(qpu_somatcopy_t_512x32_orig),
+              qpu_somatcopy_t_512x32_handle, qpu_somatcopy_t_512x32);
+  free_memory(sizeof(qpu_somatcopy_t_4x4_orig), qpu_somatcopy_t_4x4_handle,
+              qpu_somatcopy_t_4x4);
+  free_memory(sizeof(qpu_somatcopy_n_orig), qpu_somatcopy_n_handle,
+              qpu_somatcopy_n);
+}

--- a/src/qmkl6.cpp
+++ b/src/qmkl6.cpp
@@ -32,6 +32,7 @@ qmkl6_context::qmkl6_context(void) {
   init_blas1();
   init_blas2();
   init_blas3();
+  init_blaslike();
 }
 
 qmkl6_context::~qmkl6_context(void) {
@@ -39,6 +40,7 @@ qmkl6_context::~qmkl6_context(void) {
 
   mkl_set_exit_handler(exit);
 
+  finalize_blaslike();
   finalize_blas3();
   finalize_blas2();
   finalize_blas1();

--- a/src/somatcopy_n.py
+++ b/src/somatcopy_n.py
@@ -1,0 +1,197 @@
+
+import sys
+
+from videocore6 import pack_unpack
+from videocore6.assembler import assemble, qpu
+
+
+def ilog2(n):
+    '''
+    >>> ilog2(1.)
+    Traceback (most recent call last):
+    AssertionError
+    >>> ilog2(-1)
+    Traceback (most recent call last):
+    AssertionError
+    >>> ilog2(0)
+    Traceback (most recent call last):
+    AssertionError
+    >>> ilog2(1)
+    0
+    >>> ilog2(2)
+    1
+    >>> ilog2(4)
+    2
+    >>> ilog2(8)
+    3
+    '''
+
+    assert isinstance(n, int)
+    assert n > 0
+    assert n & (n - 1) == 0
+
+    return n.bit_length() - 1
+
+
+@qpu
+def qpu_somatcopy_n(asm, *, num_qpus, unroll, code_offset,
+                    align_cond=lambda pos: True):
+
+    assert unroll in [1, 2, 4, 8]
+
+    g = globals()
+    for i, v in enumerate(['rows', 'cols', 'alpha', 'a', 'lda', 'b', 'ldb',
+                           'qpu_num', 'a_i', 'b_i', 'inc', 'rest_i', 'rest_j']):
+        g[f'reg_{v}'] = rf[i]
+
+    nop(sig=ldunifrf(reg_rows))
+    nop(sig=ldunifrf(reg_cols))
+    nop(sig=ldunifrf(reg_alpha))
+    nop(sig=ldunifrf(reg_a))
+    nop(sig=ldunifrf(reg_lda))
+    nop(sig=ldunifrf(reg_b))
+    nop(sig=ldunifrf(reg_ldb))
+
+    if num_qpus == 1:
+        mov(reg_qpu_num, 0)
+    elif num_qpus == 8:
+        tidx(r0)
+        shr(r0, r0, 2)
+        band(reg_qpu_num, r0, 0b1111)
+    else:
+        raise Exception('num_qpus must be 1 or 8')
+
+    # a += 4 * lda * qpu_num + 4 * eidx
+    # b += 4 * ldb * qpu_num + 4 * eidx
+    eidx(r1).umul24(r0, reg_lda, reg_qpu_num)
+    shl(r1, r1, ilog2(4)).add(reg_a, reg_a, r0)
+    add(reg_a, reg_a, r1).add(reg_a_i, reg_a, r1)
+    umul24(r0, reg_ldb, reg_qpu_num)
+    add(reg_b, reg_b, r0)
+    add(reg_b, reg_b, r1).add(reg_b_i, reg_b, r1)
+
+    # lda *= num_qpus
+    # ldb *= num_qpus
+    umul24(reg_lda, reg_lda, num_qpus)
+    umul24(reg_ldb, reg_ldb, num_qpus)
+
+    shl(reg_inc, 4, 4)
+
+    # rest_i = rows - qpu_num - 1
+    sub(r0, reg_rows, reg_qpu_num)
+    sub(reg_rest_i, r0, 1)
+
+    nop(sig=thrsw)
+    nop()
+    nop()
+
+    while not align_cond(code_offset + len(asm)):
+        nop()
+
+    with loop as li:
+
+        shr(r0, reg_cols, ilog2(16) + ilog2(unroll), cond='pushz')
+        b(R.rest_j, cond='a0')
+        nop()
+        nop()
+        sub(reg_rest_j, r0, 2, cond='pushn')
+
+        for i in range(unroll - 3):
+            mov(tmua, reg_a).add(reg_a, reg_a, reg_inc)
+
+        b(R.skip_j_unroll, cond='a0')
+        mov(tmua, reg_a).add(reg_a, reg_a, reg_inc)
+        mov(tmua, reg_a).add(reg_a, reg_a, reg_inc) if unroll >= 2 else nop()
+        mov(tmua, reg_a).add(reg_a, reg_a, reg_inc) if unroll >= 3 else nop()
+
+        with loop as lj:
+
+            sub(reg_rest_j, reg_rest_j, 1, cond='pushn')
+
+            for i in range(unroll - 1):
+                nop(sig=ldtmu(r0))
+                fmul(tmud, r0, reg_alpha)
+                mov(tmua, reg_b).add(reg_b, reg_b, reg_inc)
+                mov(tmua, reg_a).add(reg_a, reg_a, reg_inc)
+
+            nop(sig=ldtmu(r0))
+            lj.b(cond='na0')
+            fmul(tmud, r0, reg_alpha)
+            mov(tmua, reg_b).add(reg_b, reg_b, reg_inc)
+            mov(tmua, reg_a).add(reg_a, reg_a, reg_inc)
+
+        L.skip_j_unroll
+
+        for i in range(unroll):
+            nop(sig=ldtmu(r0))
+            fmul(tmud, r0, reg_alpha)
+            mov(tmua, reg_b).add(reg_b, reg_b, reg_inc)
+
+        L.rest_j
+
+        mov(r0, 1)
+        shl(r0, r0, ilog2(16) + ilog2(unroll))
+        sub(r0, r0, 1)
+        band(r0, reg_cols, r0, cond='pushz')
+        b(R.exit_j, cond='a0')
+        sub(r0, r0, 1)
+        add(r0, r0, -16, cond='pushn').mov(r1, r0)
+        nop()
+        with loop as lj0:
+            lj0.b(cond='na0')
+            mov(tmua, reg_a).add(reg_a, reg_a, reg_inc)
+            add(r0, r0, -16, cond='pushn')
+            nop()
+        with loop as lj1:
+            sub(r5, -1, r1)
+            nop(sig=ldtmu(r0))
+            mov(r3, reg_b)
+            rotate(r0, r0, r5)
+            rotate(r3, r3, r5)
+            fmul(tmud, r0, reg_alpha)
+
+            mov(broadcast, reg_b).add(reg_b, reg_b, reg_inc)
+            eidx(r0).add(r2, r1, -16)
+            add(null, r0, r2, cond='pushn')
+            mov(r3, r5, cond='ifa')
+
+            add(r1, r1, -16, cond='pushn')
+            lj1.b(cond='na0')
+            mov(tmua, r3)
+            nop()
+            nop()
+
+        L.exit_j
+
+        sub(reg_rest_i, reg_rest_i, num_qpus, cond='pushn')
+        li.b(cond='na0')
+        add(reg_a_i, reg_a_i, reg_lda)
+        add(reg_b_i, reg_b_i, reg_ldb)
+        mov(reg_a, reg_a_i).mov(reg_b, reg_b_i)
+
+    barrierid(syncb, sig=thrsw)
+    nop()
+    nop()
+
+    nop(sig=thrsw)
+    nop(sig=thrsw)
+    nop()
+    nop()
+    nop(sig=thrsw)
+    nop()
+    nop()
+    nop()
+
+
+def main():
+
+    num_qpus, unroll, code_offset = map(int, sys.argv[1:])
+
+    for insn in assemble(qpu_somatcopy_n, num_qpus=num_qpus, unroll=unroll,
+                         code_offset=code_offset):
+        print(f'UINT64_C({insn:#018x}),')
+
+
+if __name__ == '__main__':
+
+    main()

--- a/src/somatcopy_t.py
+++ b/src/somatcopy_t.py
@@ -1,0 +1,277 @@
+
+import sys
+
+from videocore6 import pack_unpack
+from videocore6.assembler import assemble, qpu
+
+
+def ilog2(n):
+    '''
+    >>> ilog2(1.)
+    Traceback (most recent call last):
+    AssertionError
+    >>> ilog2(-1)
+    Traceback (most recent call last):
+    AssertionError
+    >>> ilog2(0)
+    Traceback (most recent call last):
+    AssertionError
+    >>> ilog2(1)
+    0
+    >>> ilog2(2)
+    1
+    >>> ilog2(4)
+    2
+    >>> ilog2(8)
+    3
+    '''
+
+    assert isinstance(n, int)
+    assert n > 0
+    assert n & (n - 1) == 0
+
+    return n.bit_length() - 1
+
+
+@qpu
+def qpu_somatcopy_t(asm, *, num_qpus, tile_rows, tile_cols, subtile_rows,
+                    subtile_cols, code_offset, align_cond=lambda pos: True):
+
+    tile_size = tile_rows * tile_cols
+    assert 1 <= tile_size <= 64
+
+    assert subtile_rows * subtile_cols == 16
+
+    IDX4_ROWS, IDX4_COLS, IDX4_ALPHA, IDX4_A_I, IDX4_A_J, IDX4_B_I, IDX4_B_J, \
+        IDX4_LDA, IDX4_LDB, IDX4_I, IDX4_J = range(11)
+
+    # r0 = eidx
+    # r1 = qpu_num
+    eidx(r0).mov(r4, 0)
+    if num_qpus == 1:
+        mov(r1, 0)
+    elif num_qpus == 8:
+        tidx(r1)
+        shr(r1, r1, 2)
+        band(r1, r1, 0b1111)
+    else:
+        raise Exception('num_qpus must be 1 or 8')
+
+    for idx in [IDX4_ROWS, IDX4_COLS, IDX4_ALPHA, IDX4_A_I, IDX4_LDA, IDX4_B_I,
+                IDX4_LDB]:
+        nop(sig=ldunif)
+        sub(null, r0, idx, cond='pushz')
+        mov(r4, r5, cond='ifa')
+
+    # I = ROWS / subtile_rows / tile_rows - qpu_num - num_qpus - 1
+    sub(null, r0, IDX4_I, cond='pushz')
+    rotate(broadcast, r4, -IDX4_ROWS)
+    shr(r5, r5, ilog2(tile_rows * subtile_rows))
+    sub(r5, r5, r1)
+    sub(r4, r5, num_qpus + 1, cond='ifa')
+
+    # A_I += LDA * qpu_num * tile_rows * subtile_rows * 4
+    # B_I += qpu_num * tile_rows * subtile_rows * 4
+    shl(r1, r1, ilog2(tile_rows * subtile_rows))
+    rotate(broadcast, r4, -IDX4_LDA)
+    sub(null, r0, IDX4_A_I, cond='pushz').umul24(r5, r1, r5)
+    add(r4, r4, r5, cond='ifa').umul24(r5, r1, 4)
+    sub(null, r0, IDX4_B_I, cond='pushz')
+    add(r4, r4, r5, cond='ifa')
+
+    nop(sig=thrsw)
+    nop()
+    nop()
+
+    while not align_cond(code_offset + len(asm)):
+        nop()
+
+    with loop as li:
+
+        # J = COLS / subtile_cols / tile_cols - 1
+        eidx(r0).rotate(broadcast, r4, -IDX4_COLS)
+        sub(null, r0, IDX4_J, cond='pushz')
+        shr(r5, r5, ilog2(tile_cols * subtile_cols))
+        sub(r4, r5, 1, cond='ifa')
+
+        # A_J = A_I
+        # B_J = B_I
+        sub(null, r0, IDX4_A_J, cond='pushz')
+        rotate(broadcast, r4, -IDX4_A_I)
+        mov(r4, r5, cond='ifa')
+        sub(null, r0, IDX4_B_J, cond='pushz')
+        rotate(broadcast, r4, -IDX4_B_I)
+        mov(r4, r5, cond='ifa')
+
+        with loop as lj:
+
+            # r0 = A_J + eidx / subtile_cols * LDA * 4 + eidx % subtile_cols * 4
+            # r1 = subtile_cols * 4
+            eidx(r1).rotate(broadcast, r4, -IDX4_A_J)
+            band(r0, r1, subtile_cols - 1)
+            shl(r0, r0, ilog2(4))
+            add(r0, r0, r5).rotate(broadcast, r4, -IDX4_LDA)
+            shr(r1, r1, ilog2(subtile_cols))
+            mov(r5, 1).umul24(r1, r1, r5)
+            shl(r1, r5, ilog2(subtile_cols * 4)).add(r0, r0, r1)
+
+            tmu_unroll = min(tile_size, 8)
+
+            for i in range(tile_size + tmu_unroll):
+                if i > 0 and i % tile_cols == 0:
+                    # r0 = -tile_cols * subtile_cols * 4 + LDA * subtile_rows * 4
+                    shl(r5, r1, ilog2(tile_cols))
+                    sub(r0, r0, r5).rotate(broadcast, r4, -IDX4_LDA)
+                    shl(r5, r5, ilog2(subtile_rows))
+                    add(r0, r0, r5)
+                if i < tmu_unroll:
+                    mov(tmua, r0).add(r0, r0, r1)
+                if tmu_unroll <= i:
+                    nop(sig=ldtmu(rf[i - tmu_unroll]))
+                if tmu_unroll <= i < tile_size:
+                    mov(tmua, r0).add(r0, r0, r1)
+
+            # r0 = B_J + eidx % subtile_cols * LDB * 4 + eidx / subtile_cols * 4
+            # r1 = subtile_rows * 4
+            # r5 = ALPHA
+            eidx(r1).rotate(broadcast, r4, -IDX4_B_J)
+            shr(r0, r1, ilog2(subtile_cols))
+            shl(r0, r0, ilog2(4))
+            add(r0, r0, r5).rotate(broadcast, r4, -IDX4_LDB)
+            band(r1, r1, subtile_cols - 1)
+            mov(r5, 1).umul24(r1, r1, r5)
+            shl(r1, r5, ilog2(subtile_rows * 4)).add(r0, r0, r1)
+            rotate(broadcast, r4, -IDX4_ALPHA)
+
+            for i in range(tile_size):
+                if i > 0 and i % tile_rows == 0:
+                    # r0 = -tile_rows * subtile_rows * 4 + LDB * subtile_cols * 4
+                    shl(r5, r1, ilog2(tile_rows))
+                    sub(r0, r0, r5).rotate(broadcast, r4, -IDX4_LDB)
+                    shl(r5, r5, ilog2(subtile_cols))
+                    add(r0, r0, r5).rotate(broadcast, r4, -IDX4_ALPHA)
+                fmul(tmud, rf[i % tile_rows * tile_cols + i // tile_rows], r5)
+                mov(tmua, r0).add(r0, r0, r1)
+
+            # A_J += tile_cols * subtile_cols * 4
+            # B_J += LDB * tile_cols * subtile_cols * 4
+            eidx(r0).mov(r5, 1)
+            sub(null, r0, IDX4_A_J, cond='pushz')
+            shl(r5, r5, ilog2(tile_cols * subtile_cols * 4))
+            add(r4, r4, r5, cond='ifa').rotate(broadcast, r4, -IDX4_LDB)
+            sub(null, r0, IDX4_B_J, cond='pushz')
+            shl(r5, r5, ilog2(tile_cols * subtile_cols))
+            add(r4, r4, r5, cond='ifa')
+
+            rotate(null, r4, -IDX4_J, cond='pushz')
+            lj.b(cond='na0')
+            sub(null, r0, IDX4_J, cond='pushz')
+            sub(r4, r4, 1, cond='ifa')
+            nop()
+
+        # A_I += LDA * num_qpus * tile_rows * subtile_rows * 4
+        # B_I += num_qpus * tile_rows * subtile_rows * 4
+        eidx(r0).rotate(broadcast, r4, -IDX4_LDA)
+        mov(r1, 1)
+        shl(r1, r1, ilog2(num_qpus * tile_rows * subtile_rows))
+        sub(null, r0, IDX4_A_I, cond='pushz').umul24(r5, r1, r5)
+        add(r4, r4, r5, cond='ifa').sub(null, r0, IDX4_B_I, cond='pushz')
+        shl(r5, r1, ilog2(4))
+        add(r4, r4, r5, cond='ifa')
+
+        rotate(null, r4, -IDX4_I, cond='pushn')
+        li.b(cond='na0')
+        sub(null, r0, IDX4_I, cond='pushz')
+        sub(r4, r4, num_qpus, cond='ifa')
+        nop()
+
+    barrierid(syncb, sig=thrsw)
+    nop()
+    nop()
+
+    nop(sig=thrsw)
+    nop(sig=thrsw)
+    nop()
+    nop()
+    nop(sig=thrsw)
+    nop()
+    nop()
+    nop()
+
+
+def benchmark():
+
+    from time import monotonic
+
+    import numpy as np
+
+    from videocore6.driver import Driver
+
+    def run(drv, unif, src, dst, num_qpus, rows, cols, tile_rows, tile_cols,
+            subtile_rows, subtile_cols, code_offset=0):
+
+        code = drv.program(qpu_somatcopy_t, num_qpus=num_qpus,
+                           tile_rows=tile_rows, tile_cols=tile_cols,
+                           subtile_rows=subtile_rows, subtile_cols=subtile_cols,
+                           code_offset=code_offset)
+
+        src[:, :] = np.arange(src.size, dtype=src.dtype).reshape(src.shape)
+        dst[:, :] = np.arange(dst.size, dtype=dst.dtype).reshape(dst.shape)
+
+        unif[0] = rows
+        unif[1] = cols
+        unif[2] = pack_unpack('f', 'I', 1.)
+        unif[3] = src.addresses()[0, 0]
+        unif[4] = cols * 4
+        unif[5] = dst.addresses()[0, 0]
+        unif[6] = rows * 4
+
+        start = monotonic()
+        drv.execute(code, unif.addresses()[0], thread=num_qpus)
+        end = monotonic()
+
+        print(f'{rows} x {cols} matrix, ' +
+              f'{tile_rows:2} x {tile_cols:2} tile, ' +
+              f'{subtile_rows:2} x {subtile_cols:2} subtile: ' +
+              f'{end - start} seconds, ' +
+              f'{rows * cols * 4 / (end - start) * 1e-6} MB/s')
+
+    rows = 8192
+    cols = 8192
+
+    with Driver(data_area_size=600 * 1024 * 1024) as drv:
+
+        unif = drv.alloc(7, dtype='uint32')
+        src = drv.alloc((rows, cols), dtype='uint32')
+        dst = drv.alloc((cols, rows), dtype='uint32')
+
+        for num_qpus in [1, 8]:
+            run(drv, unif, src, dst, num_qpus, rows, cols, 8, 8, 4, 4)
+
+        for tile_rows in [2, 4, 8, 16, 32]:
+            tile_cols = 64 // tile_rows
+            for subtile_rows in [2, 4, 8]:
+                subtile_cols = 16 // subtile_rows
+                run(drv, unif, src, dst, 8, rows, cols, tile_rows, tile_cols,
+                    subtile_rows, subtile_cols)
+
+
+def main():
+
+    if len(sys.argv) == 1:
+        benchmark()
+        return
+
+    num_qpus, tile_rows, tile_cols, subtile_rows, subtile_cols, code_offset \
+        = map(int, sys.argv[1:])
+
+    for insn in assemble(qpu_somatcopy_t, num_qpus=num_qpus,
+                         tile_rows=tile_rows, tile_cols=tile_cols,
+                         subtile_rows=subtile_rows, subtile_cols=subtile_cols,
+                         code_offset=code_offset):
+        print(f'UINT64_C({insn:#018x}),')
+
+
+if __name__ == '__main__':
+
+    main()

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -37,7 +37,8 @@ void* mkl_malloc(const size_t alloc_size, int alignment) {
   void* const virt_addr =
       qmkl6.alloc_memory(alloc_size_aligned, handle, bus_addr);
 
-  const uint32_t offset = ((uint32_t)alignment - bus_addr) & (alignment - 1);
+  /* bus_addr + offset ≡ 0 (mod alignment) */
+  const uint32_t offset = -bus_addr & (alignment - 1);
   void* const virt_addr_aligned = (void*)((uintptr_t)virt_addr + offset);
 
   struct qmkl6_context::memory_area area = {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,9 +26,14 @@ foreach (blas IN ITEMS qmkl6 netlib openblas atlas mkl)
     endif ()
 
     foreach (test IN ITEMS mem sasum saxpy scopy sdot snrm2 sscal sgemv stbmv
-                           sgemm)
+                           sgemm somatcopy)
 
-        if (NOT blas STREQUAL qmkl6 AND test STREQUAL mem)
+        if (test STREQUAL mem AND NOT blas STREQUAL qmkl6)
+            continue()
+        endif ()
+
+        if (test STREQUAL somatcopy
+            AND NOT blas MATCHES "^(openblas|mkl|qmkl6)$")
             continue()
         endif ()
 

--- a/test/cblasdefs.h
+++ b/test/cblasdefs.h
@@ -58,6 +58,19 @@ __attribute__((__unused__)) static double dsecnd(void) {
 
 #endif /* !defined(CBLAS_mkl) && !defined(CBLAS_qmkl6) */
 
+#if defined(CBLAS_mkl)
+
+__attribute__((__unused__)) static void cblas_somatcopy(
+    const CBLAS_LAYOUT layout, const CBLAS_TRANSPOSE trans, const int rows,
+    const int cols, const float alpha, const float* const a, const int lda,
+    float* const b, const int ldb) {
+  mkl_somatcopy(layout == CblasRowMajor ? 'r' : 'c',
+                trans == CblasNoTrans ? 'n' : 't', rows, cols, alpha, a, lda, b,
+                ldb);
+}
+
+#endif /* defined(CBLAS_mkl) */
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/test/somatcopy.cpp
+++ b/test/somatcopy.cpp
@@ -1,0 +1,224 @@
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <random>
+
+#include "cblasdefs.h"
+
+static void naive_somatcopy_n(const int rows, const int cols, const float alpha,
+                              const float* const a, const int lda,
+                              float* const b, const int ldb) {
+#pragma omp parallel default(none) \
+    firstprivate(rows, cols, alpha, a, lda, b, ldb) num_threads(1)
+  {
+    constexpr int block_rows = 8, block_cols = std::numeric_limits<int>::max();
+
+#pragma omp for collapse(1) schedule(guided)
+    for (int i = 0; i < rows; i += block_rows) {
+      for (int j = 0; j < cols; j += block_cols) {
+        const int bound_ii = (rows - i < block_rows) ? (rows - i) : block_rows,
+                  bound_jj = (cols - j < block_cols) ? (cols - j) : block_cols;
+        for (int ii = 0; ii < bound_ii; ++ii)
+          for (int jj = 0; jj < bound_jj; ++jj)
+            b[ldb * i + j + ldb * ii + jj] =
+                alpha * a[lda * i + j + lda * ii + jj];
+      }
+    }
+  }
+}
+
+static void naive_somatcopy_t(const int rows, const int cols, const float alpha,
+                              const float* const a, const int lda,
+                              float* const b, const int ldb) {
+#pragma omp parallel default(none) \
+    firstprivate(rows, cols, alpha, a, lda, b, ldb)
+  {
+    constexpr int block_rows = 32, block_cols = 32;
+    float block[block_rows * block_cols];
+
+#pragma omp for collapse(2) schedule(guided)
+    for (int i = 0; i < rows; i += block_rows) {
+      for (int j = 0; j < cols; j += block_cols) {
+        const int bound_ii = (rows - i < block_rows) ? (rows - i) : block_rows,
+                  bound_jj = (cols - j < block_cols) ? (cols - j) : block_cols,
+                  ld = block_cols;
+        for (int ii = 0; ii < bound_ii; ++ii)
+          for (int jj = 0; jj < bound_jj; ++jj)
+            block[ld * ii + jj] = alpha * a[lda * i + j + lda * ii + jj];
+        for (int jj = 0; jj < bound_jj; ++jj)
+          for (int ii = 0; ii < bound_ii; ++ii)
+            b[ldb * j + i + ldb * jj + ii] = block[ld * ii + jj];
+      }
+    }
+  }
+}
+
+static void naive_somatcopy(const CBLAS_LAYOUT layout,
+                            const CBLAS_TRANSPOSE trans, const int rows,
+                            const int cols, const float alpha,
+                            const float* const a, const int lda, float* const b,
+                            const int ldb) {
+  if (layout == CblasRowMajor && trans == CblasNoTrans)
+    naive_somatcopy_n(rows, cols, alpha, a, lda, b, ldb);
+  else if (layout == CblasRowMajor && trans == CblasTrans)
+    naive_somatcopy_t(rows, cols, alpha, a, lda, b, ldb);
+  else if (layout == CblasColMajor && trans == CblasNoTrans)
+    naive_somatcopy_n(cols, rows, alpha, a, lda, b, ldb);
+  else if (layout == CblasColMajor && trans == CblasTrans)
+    naive_somatcopy_t(cols, rows, alpha, a, lda, b, ldb);
+  else {
+    std::cerr << "error: Unsupported layout and trans" << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+template <class Generator>
+static int test_somatcopy_single(const CBLAS_LAYOUT layout,
+                                 const CBLAS_TRANSPOSE trans, const int rows,
+                                 const int cols, const int lda, const int ldb,
+                                 Generator& gen) {
+  std::uniform_real_distribution<float> dist;
+  const float alpha = dist(gen);
+  int a_len, b_len;
+  float *a_host, *a_qpu, *b_host, *b_qpu;
+
+  printf("%c%c: rows = %5d, cols = %5d, alpha = %f, lda = %5d, ldb = %5d: ",
+         (layout == CblasRowMajor) ? 'R' : 'C',
+         (trans == CblasNoTrans) ? 'N' : 'T', rows, cols, alpha, lda, ldb);
+
+  if (layout == CblasRowMajor) {
+    if (lda < cols) {
+      std::cerr << "error: lda must be >= cols for row major" << std::endl;
+      return 1;
+    }
+    a_len = rows * lda;
+  } else {
+    if (lda < rows) {
+      std::cerr << "error: lda must be >= rows for col major" << std::endl;
+      return 1;
+    }
+    a_len = cols * lda;
+  }
+
+  if ((layout == CblasRowMajor) == (trans == CblasNoTrans)) {
+    if (ldb < cols) {
+      std::cerr << "error: ldb must be >= cols for row major, no trans type"
+                << std::endl;
+      return 1;
+    }
+    b_len = rows * ldb;
+  } else {
+    if (ldb < rows) {
+      std::cerr << "error: ldb must be >= rows for row major, trans type"
+                << std::endl;
+      return 1;
+    }
+    b_len = cols * ldb;
+  }
+
+  a_host = new float[a_len];
+  a_qpu = (float*)mkl_malloc(a_len * sizeof(float), 64);
+  std::generate(a_host, a_host + a_len, std::bind(dist, gen));
+  std::copy(a_host, a_host + a_len, a_qpu);
+
+  b_host = new float[b_len];
+  b_qpu = (float*)mkl_malloc(b_len * sizeof(float), 64);
+  std::generate(b_host, b_host + b_len, std::bind(dist, gen));
+  std::copy(b_host, b_host + b_len, b_qpu);
+
+  const double start_host = dsecnd();
+  naive_somatcopy(layout, trans, rows, cols, alpha, a_host, lda, b_host, ldb);
+  const double time_host = dsecnd() - start_host;
+
+  const double start_qpu = dsecnd();
+  cblas_somatcopy(layout, trans, rows, cols, alpha, a_qpu, lda, b_qpu, ldb);
+  const double time_qpu = dsecnd() - start_qpu;
+
+  float err_abs_min = HUGE_VALF, err_abs_max = -HUGE_VALF;
+  float err_rel_min = HUGE_VALF, err_rel_max = -HUGE_VALF;
+  for (int i = 0; i < b_len; ++i) {
+    const float err_abs = std::abs(b_host[i] - b_qpu[i]);
+    const float err_rel = std::abs(err_abs / b_host[i]);
+    err_abs_min = std::min(err_abs_min, err_abs);
+    err_abs_max = std::max(err_abs_max, err_abs);
+    err_rel_min = std::min(err_rel_min, err_rel);
+    err_rel_max = std::max(err_rel_max, err_rel);
+  }
+
+  printf(
+      "err_abs = [%f, %f], "
+      "err_rel = [%f, %f], "
+      "%f sec -> %f sec, "
+      "%f MB/s -> %f MB/s\n",
+      err_abs_min, err_abs_max, err_rel_min, err_rel_max, time_host, time_qpu,
+      rows * cols / time_host * 1e-6, rows * cols / time_qpu * 1e-6);
+
+  if (err_rel_max >= 1e-3f) {
+    std::cerr << "error: Relative error is too large" << std::endl;
+    return 1;
+  }
+
+  delete[] a_host;
+  delete[] b_host;
+  mkl_free(a_qpu);
+  mkl_free(b_qpu);
+  return 0;
+}
+
+template <class Generator>
+static int test_somatcopy_random(const CBLAS_LAYOUT layout,
+                                 const CBLAS_TRANSPOSE trans, Generator& gen) {
+  std::uniform_int_distribution<int> dist;
+
+  const int dim_mask = (trans == CblasTrans) ? ~3 : ~0;
+
+  dist.param(decltype(dist)::param_type(1, 1 << 11));
+  const int rows = dist(gen) & dim_mask, cols = dist(gen) & dim_mask;
+
+  if (layout == CblasRowMajor)
+    dist.param(decltype(dist)::param_type(cols, cols * 4));
+  else
+    dist.param(decltype(dist)::param_type(rows, rows * 4));
+  const int lda = dist(gen);
+
+  if ((layout == CblasRowMajor) == (trans == CblasNoTrans))
+    dist.param(decltype(dist)::param_type(cols, cols * 4));
+  else
+    dist.param(decltype(dist)::param_type(rows, rows * 4));
+  const int ldb = dist(gen);
+
+  return test_somatcopy_single(layout, trans, rows, cols, lda, ldb, gen);
+}
+
+int main(void) {
+  std::setbuf(stdout, NULL);
+
+  std::default_random_engine gen;
+  int ret;
+
+  for (const CBLAS_LAYOUT layout : {CblasRowMajor, CblasColMajor}) {
+    const int rows = 2048, cols = 4096;
+    const int lda = (layout == CblasRowMajor) ? cols : rows;
+    for (const CBLAS_TRANSPOSE trans : {CblasNoTrans, CblasTrans}) {
+      const int ldb =
+          ((layout == CblasRowMajor) == (trans == CblasNoTrans)) ? cols : rows;
+      ret = test_somatcopy_single(layout, trans, rows, cols, lda, ldb, gen);
+      if (ret) return ret;
+    }
+  }
+
+  for (const CBLAS_LAYOUT layout : {CblasRowMajor, CblasColMajor}) {
+    for (const CBLAS_TRANSPOSE trans : {CblasNoTrans, CblasTrans}) {
+      for (int i = 0; i < 5; ++i) {
+        ret = test_somatcopy_random(layout, trans, gen);
+        if (ret) return ret;
+      }
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This pull request adds the somatcopy (out-of-place matrix copy and transposition) kernel, which is classified as a BLAS-like extension by Intel MKL.
Currently, the number of rows and columns is limited to a multiple of four for transpose operations.

Minor refactors for other portions of this software are also included in this pull request.